### PR TITLE
Make the stack only use the region of the stack environment instead of environment variable

### DIFF
--- a/lib/event-replay-engine.ts
+++ b/lib/event-replay-engine.ts
@@ -76,7 +76,7 @@ export class EventReplayEngine extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    const region: string = process.env.REGION!;
+    const region = this.region;
     console.log(__dirname);
     console.log("Current Region: ", region);
 


### PR DESCRIPTION
Some of the stack implementation uses region from the environment variable.
If the region from the environment variable and the region from the region from the AWS cli configuration are different, the stack will be broken.
We should use a single source of truth for the region and it will be the region from the AWS cli configuration.