### PR TITLE
Make the S3 bucket for CloudFront access log to use ACL explicitly.

### DIFF
--- a/lib/cloudfront-streaming.ts
+++ b/lib/cloudfront-streaming.ts
@@ -35,12 +35,9 @@ export class CloudFrontForStreaming extends Construct {
       autoDeleteObjects: true,
       encryption: s3.BucketEncryption.S3_MANAGED,
       enforceSSL: true,
-      blockPublicAccess: new s3.BlockPublicAccess({
-        blockPublicPolicy: true,
-        blockPublicAcls: true,
-        ignorePublicAcls: true,
-        restrictPublicBuckets: true,
-      }),
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      accessControl: s3.BucketAccessControl.BUCKET_OWNER_FULL_CONTROL,
+      objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED
     });
     NagSuppressions.addResourceSuppressions(s3Logs, [
       {


### PR DESCRIPTION
Based on the document https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership, the default acl setting has been changed to disabling ACLs.
Due to the change, cdk deployment fails with an error.
